### PR TITLE
Add stat blocks, columns, zoom, and editable built-in themes

### DIFF
--- a/built-in/dnd-homebrew.css
+++ b/built-in/dnd-homebrew.css
@@ -221,36 +221,139 @@ img {
    D&D CALLOUTS
    ============================================================ */
 
-/* --- Stat Block --- */
+/* --- Stat Block (shared styling for stat-block and stat-block-wide) --- */
 .callout-stat-block,
-.callout[data-callout="stat-block"] {
+.callout[data-callout="stat-block"],
+.callout-stat-block-wide,
+.callout[data-callout="stat-block-wide"] {
 	background-color: #fdf1dc;
-	border: none;
-	border-top: 3px solid #9c2b1b;
-	border-bottom: 3px solid #9c2b1b;
-	border-radius: 0;
-	padding: 0.6em 0.8em;
+	border: 1px solid #c9ad6a;
+	border-radius: 8px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	padding: 0.8em 1em;
 	margin: 0.8em 0;
 	page-break-inside: avoid;
 }
 
+/* Hide the callout title bar */
 .callout-stat-block .callout-title,
-.callout[data-callout="stat-block"] .callout-title {
-	color: #58180d;
-	font-size: 14pt;
-	font-variant: small-caps;
-	letter-spacing: 0.03em;
-	text-transform: none;
-	border-bottom: 1px solid #9c2b1b;
-	padding-bottom: 0.2em;
-	margin-bottom: 0.3em;
+.callout[data-callout="stat-block"] .callout-title,
+.callout-stat-block-wide .callout-title,
+.callout[data-callout="stat-block-wide"] .callout-title {
+	display: none;
 }
 
+/* Creature name (h2 inside stat block) */
+.callout-stat-block h2,
+.callout[data-callout="stat-block"] h2,
+.callout-stat-block-wide h2,
+.callout[data-callout="stat-block-wide"] h2 {
+	font-size: 16pt;
+	font-variant: small-caps;
+	font-weight: 700;
+	color: #58180d;
+	margin: 0 0 0.1em 0;
+	padding: 0;
+	border-bottom: 2px solid #9c2b1b;
+	padding-bottom: 0.1em;
+}
+
+/* Creature type line (italic em after h2) */
+.callout-stat-block .callout-content > p:first-of-type em,
+.callout[data-callout="stat-block"] .callout-content > p:first-of-type em,
+.callout-stat-block-wide .callout-content > p:first-of-type em,
+.callout[data-callout="stat-block-wide"] .callout-content > p:first-of-type em {
+	font-size: 9pt;
+	color: #333;
+}
+
+/* Section headers (h3 — Traits, Actions, Bonus Actions) */
+.callout-stat-block h3,
+.callout[data-callout="stat-block"] h3,
+.callout-stat-block-wide h3,
+.callout[data-callout="stat-block-wide"] h3 {
+	font-size: 12pt;
+	font-variant: small-caps;
+	font-weight: 700;
+	color: #58180d;
+	margin: 0.5em 0 0.2em 0;
+	border-bottom: 1px solid #9c2b1b;
+	padding-bottom: 0.1em;
+}
+
+/* Gradient dividers */
 .callout-stat-block hr,
-.callout[data-callout="stat-block"] hr {
-	height: 1px;
+.callout[data-callout="stat-block"] hr,
+.callout-stat-block-wide hr,
+.callout[data-callout="stat-block-wide"] hr {
+	height: 2px;
 	background: linear-gradient(to right, transparent, #9c2b1b, transparent);
 	margin: 0.4em 0;
+}
+
+/* Compact content spacing */
+.callout-stat-block .callout-content p,
+.callout[data-callout="stat-block"] .callout-content p,
+.callout-stat-block-wide .callout-content p,
+.callout[data-callout="stat-block-wide"] .callout-content p {
+	margin: 0.15em 0;
+	font-size: 9pt;
+}
+
+/* Stat ability table (STR/DEX/CON/INT/WIS/CHA) */
+.callout-stat-block table,
+.callout[data-callout="stat-block"] table,
+.callout-stat-block-wide table,
+.callout[data-callout="stat-block-wide"] table {
+	margin: 0.3em 0;
+	width: 100%;
+	font-size: 9pt;
+}
+
+.callout-stat-block th,
+.callout[data-callout="stat-block"] th,
+.callout-stat-block-wide th,
+.callout[data-callout="stat-block-wide"] th {
+	text-align: center;
+	font-size: 8pt;
+	font-variant: small-caps;
+	font-weight: 700;
+	color: #58180d;
+	padding: 0.2em 0.4em;
+	background: transparent;
+	border-bottom: none;
+}
+
+.callout-stat-block td,
+.callout[data-callout="stat-block"] td,
+.callout-stat-block-wide td,
+.callout[data-callout="stat-block-wide"] td {
+	text-align: center;
+	font-size: 9pt;
+	padding: 0.2em 0.4em;
+	border-bottom: none;
+	background: transparent;
+}
+
+.callout-stat-block tr:nth-child(even) td,
+.callout[data-callout="stat-block"] tr:nth-child(even) td,
+.callout-stat-block-wide tr:nth-child(even) td,
+.callout[data-callout="stat-block-wide"] tr:nth-child(even) td {
+	background: transparent;
+}
+
+/* --- Stat Block Wide — full width + 2-column content --- */
+.callout-stat-block-wide,
+.callout[data-callout="stat-block-wide"] {
+	column-span: all;
+	break-before: page;
+	page-break-before: always;
+}
+
+.callout-stat-block-wide .callout-content,
+.callout[data-callout="stat-block-wide"] .callout-content {
+	column-count: 2;
+	column-gap: 1.5em;
 }
 
 /* --- Read-Aloud Text --- */
@@ -319,16 +422,18 @@ img {
 /* --- Stat Block (on tables/divs) --- */
 .stat-block {
 	background-color: #fdf1dc;
-	border-top: 3px solid #9c2b1b;
-	border-bottom: 3px solid #9c2b1b;
-	border-left: none;
-	border-right: none;
-	padding: 0.4em 0;
+	border: 1px solid #c9ad6a;
+	border-radius: 8px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	padding: 0.8em 1em;
 	break-inside: avoid;
 }
 
 .stat-block th {
-	background-color: #9c2b1b;
+	background-color: #e8d5a8;
+	color: #58180d;
+	font-variant: small-caps;
+	border-bottom: 1px solid #9c2b1b;
 }
 
 /* --- Read-Aloud (on non-callout elements) --- */
@@ -350,6 +455,7 @@ img {
 	padding: 0.4em 0.6em;
 	break-inside: avoid;
 }
+
 
 /* --- Note Box (designer/DM notes) --- */
 .note-box {
@@ -379,7 +485,8 @@ img {
 }
 
 /* --- Full-Width (span both columns) --- */
-.full-width {
+.full-width,
+.wide {
 	column-span: all;
 }
 
@@ -439,6 +546,7 @@ img {
    ============================================================ */
 
 .page-break {
+	break-after: page;
 	page-break-after: always;
 }
 

--- a/built-in/dnd-homebrew.css
+++ b/built-in/dnd-homebrew.css
@@ -1,3 +1,451 @@
 /* dnd-homebrew.css — D&D Homebrew print theme */
 /* typeset-name: D&D Homebrew */
-/* Implemented in Issue #46: Create dnd-homebrew.css with two-column layout */
+/* typeset-layout: size=Letter, orientation=Portrait, margins=0.75in */
+
+/* ============================================================
+   BASE
+   ============================================================ */
+
+body {
+	font-family: 'Bookinsanity', 'Palatino Linotype', Palatino, 'Book Antiqua', serif;
+	font-size: 10pt;
+	line-height: 1.4;
+	color: #1a1a1a;
+	background: #f5e6c8;
+	margin: 0;
+	padding: 0;
+	column-count: 2;
+	column-gap: 20pt;
+}
+
+/* ============================================================
+   HEADINGS
+   ============================================================ */
+
+h1, h2, h3, h4, h5, h6 {
+	font-family: 'Bookinsanity', 'Palatino Linotype', Palatino, 'Book Antiqua', serif;
+	color: #58180d;
+	line-height: 1.2;
+	margin-top: 1em;
+	margin-bottom: 0.3em;
+	page-break-after: avoid;
+}
+
+h1 {
+	font-size: 22pt;
+	font-weight: 700;
+	font-variant: small-caps;
+	letter-spacing: 0.03em;
+	column-span: all;
+	margin-top: 0;
+	border-bottom: 2px solid #58180d;
+	padding-bottom: 0.15em;
+}
+
+h2 {
+	font-size: 16pt;
+	font-weight: 700;
+	border-bottom: 1px solid #58180d;
+	padding-bottom: 0.1em;
+}
+
+h3 {
+	font-size: 13pt;
+	font-weight: 700;
+	font-variant: small-caps;
+	letter-spacing: 0.03em;
+}
+
+h4 {
+	font-size: 11pt;
+	font-weight: 700;
+	font-style: italic;
+	color: #1a1a1a;
+}
+
+h5, h6 {
+	font-size: 10pt;
+	font-weight: 600;
+	font-style: italic;
+}
+
+/* ============================================================
+   PARAGRAPHS & TEXT
+   ============================================================ */
+
+p {
+	margin: 0 0 0.5em 0;
+	orphans: 2;
+	widows: 2;
+}
+
+strong, b {
+	font-weight: 700;
+}
+
+em, i {
+	font-style: italic;
+}
+
+/* ============================================================
+   LINKS
+   ============================================================ */
+
+a {
+	color: #58180d;
+	text-decoration: none;
+}
+
+/* ============================================================
+   BLOCKQUOTES
+   ============================================================ */
+
+blockquote {
+	margin: 0.8em 0;
+	padding: 0.4em 0.8em;
+	border-left: 3px solid #9c2b1b;
+	background-color: #f0ddb8;
+	color: #333333;
+	font-style: italic;
+}
+
+blockquote p {
+	margin-bottom: 0;
+}
+
+/* ============================================================
+   LISTS
+   ============================================================ */
+
+ul, ol {
+	margin: 0 0 0.5em 0;
+	padding-left: 1.4em;
+}
+
+li {
+	margin-bottom: 0.15em;
+}
+
+li > ul,
+li > ol {
+	margin-bottom: 0;
+}
+
+/* ============================================================
+   TABLES
+   ============================================================ */
+
+table {
+	width: 100%;
+	border-collapse: collapse;
+	margin: 0.8em 0;
+	font-size: 9pt;
+	page-break-inside: avoid;
+}
+
+th {
+	background-color: #58180d;
+	color: #ffffff;
+	font-weight: 700;
+	text-align: left;
+	padding: 0.35em 0.6em;
+}
+
+td {
+	padding: 0.3em 0.6em;
+	border-bottom: 1px solid #d4b990;
+	vertical-align: top;
+}
+
+tr:nth-child(even) td {
+	background-color: #f0d6a8;
+}
+
+/* ============================================================
+   HORIZONTAL RULES — D&D-style gradient divider
+   ============================================================ */
+
+hr {
+	border: none;
+	height: 2px;
+	background: linear-gradient(to right, transparent, #9c2b1b, transparent);
+	margin: 1em 0;
+}
+
+/* ============================================================
+   CODE (minimal — not a D&D focus)
+   ============================================================ */
+
+code {
+	font-family: 'Courier New', Courier, monospace;
+	font-size: 9pt;
+	background-color: #f0ddb8;
+	padding: 0.1em 0.3em;
+	border-radius: 2px;
+	color: #58180d;
+}
+
+pre {
+	font-family: 'Courier New', Courier, monospace;
+	font-size: 8.5pt;
+	background-color: #f0ddb8;
+	border: 1px solid #d4b990;
+	border-left: 3px solid #58180d;
+	padding: 0.6em 0.8em;
+	margin: 0.6em 0;
+	overflow-x: auto;
+	white-space: pre-wrap;
+	word-break: break-word;
+	page-break-inside: avoid;
+}
+
+pre code {
+	background: none;
+	padding: 0;
+	color: inherit;
+	border-radius: 0;
+}
+
+/* ============================================================
+   IMAGES
+   ============================================================ */
+
+img {
+	max-width: 100%;
+	height: auto;
+	display: block;
+	margin: 0.6em auto;
+}
+
+/* ============================================================
+   D&D CALLOUTS
+   ============================================================ */
+
+/* --- Stat Block --- */
+.callout-stat-block,
+.callout[data-callout="stat-block"] {
+	background-color: #fdf1dc;
+	border: none;
+	border-top: 3px solid #9c2b1b;
+	border-bottom: 3px solid #9c2b1b;
+	border-radius: 0;
+	padding: 0.6em 0.8em;
+	margin: 0.8em 0;
+	page-break-inside: avoid;
+}
+
+.callout-stat-block .callout-title,
+.callout[data-callout="stat-block"] .callout-title {
+	color: #58180d;
+	font-size: 14pt;
+	font-variant: small-caps;
+	letter-spacing: 0.03em;
+	text-transform: none;
+	border-bottom: 1px solid #9c2b1b;
+	padding-bottom: 0.2em;
+	margin-bottom: 0.3em;
+}
+
+.callout-stat-block hr,
+.callout[data-callout="stat-block"] hr {
+	height: 1px;
+	background: linear-gradient(to right, transparent, #9c2b1b, transparent);
+	margin: 0.4em 0;
+}
+
+/* --- Read-Aloud Text --- */
+.callout-read-aloud,
+.callout[data-callout="read-aloud"] {
+	background-color: #e0d5c0;
+	border: none;
+	border-left: 4px solid #6b8cba;
+	border-radius: 0;
+	padding: 0.8em 1em;
+	margin: 0.8em 0;
+	font-style: italic;
+	page-break-inside: avoid;
+}
+
+.callout-read-aloud .callout-title,
+.callout[data-callout="read-aloud"] .callout-title {
+	color: #4a6d8c;
+	font-style: normal;
+	font-variant: small-caps;
+	text-transform: none;
+}
+
+/* --- Magic Item --- */
+.callout-magic-item,
+.callout[data-callout="magic-item"] {
+	background-color: #faf3e0;
+	border: 1px solid #c9a84c;
+	border-left: 3px solid #c9a84c;
+	border-radius: 0;
+	padding: 0.6em 0.8em;
+	margin: 0.8em 0;
+	page-break-inside: avoid;
+}
+
+.callout-magic-item .callout-title,
+.callout[data-callout="magic-item"] .callout-title {
+	color: #7a5c1e;
+	font-style: italic;
+	text-transform: none;
+}
+
+/* --- Warning / Adventure Hook --- */
+.callout-warning,
+.callout[data-callout="warning"] {
+	background-color: #fef5e7;
+	border: none;
+	border-left: 4px solid #e67e22;
+	border-radius: 0;
+	padding: 0.6em 0.8em;
+	margin: 0.8em 0;
+	page-break-inside: avoid;
+}
+
+.callout-warning .callout-title,
+.callout[data-callout="warning"] .callout-title {
+	color: #c45a00;
+	font-weight: 700;
+	text-transform: none;
+}
+
+/* ============================================================
+   BLOCK CLASSES ({.classname} annotations)
+   ============================================================ */
+
+/* --- Stat Block (on tables/divs) --- */
+.stat-block {
+	background-color: #fdf1dc;
+	border-top: 3px solid #9c2b1b;
+	border-bottom: 3px solid #9c2b1b;
+	border-left: none;
+	border-right: none;
+	padding: 0.4em 0;
+	break-inside: avoid;
+}
+
+.stat-block th {
+	background-color: #9c2b1b;
+}
+
+/* --- Read-Aloud (on non-callout elements) --- */
+.read-aloud {
+	background-color: #e0d5c0;
+	border-left: 4px solid #6b8cba;
+	padding: 0.8em 1em;
+	font-style: italic;
+	break-inside: avoid;
+}
+
+/* --- Spell Block --- */
+.spell-block {
+	background-color: #fdf1dc;
+	border-top: 2px solid #58180d;
+	border-bottom: 2px solid #58180d;
+	border-left: none;
+	border-right: none;
+	padding: 0.4em 0.6em;
+	break-inside: avoid;
+}
+
+/* --- Note Box (designer/DM notes) --- */
+.note-box {
+	background-color: #f0ddb8;
+	border: 1px dashed #9c2b1b;
+	padding: 0.6em 0.8em;
+	font-size: 9pt;
+	break-inside: avoid;
+}
+
+/* --- Chapter Header --- */
+.chapter-header {
+	column-span: all;
+	text-align: center;
+	font-size: 26pt;
+	font-variant: small-caps;
+	color: #58180d;
+	margin: 0.5em 0;
+	border-bottom: 2px solid #58180d;
+	padding-bottom: 0.15em;
+}
+
+/* --- Two-Column (explicit subsection columns) --- */
+.two-column {
+	column-count: 2;
+	column-gap: 1.5em;
+}
+
+/* --- Full-Width (span both columns) --- */
+.full-width {
+	column-span: all;
+}
+
+/* ============================================================
+   IMAGE LAYOUT CLASSES
+   ============================================================ */
+
+.img-half-right {
+	float: right;
+	width: 48%;
+	margin: 0 0 1em 1em;
+	shape-outside: margin-box;
+}
+
+.img-half-left {
+	float: left;
+	width: 48%;
+	margin: 0 1em 1em 0;
+	shape-outside: margin-box;
+}
+
+.img-full-width {
+	column-span: all;
+	width: 100%;
+	margin: 0.6em 0;
+}
+
+.img-full-page {
+	page-break-before: always;
+	page-break-after: always;
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+}
+
+.img-quarter-right {
+	float: right;
+	width: 28%;
+	margin: 0 0 0.8em 0.8em;
+	shape-outside: margin-box;
+}
+
+.img-no-break {
+	break-inside: avoid;
+}
+
+.img-caption {
+	font-size: 9pt;
+	text-align: center;
+	font-style: italic;
+	color: #58180d;
+	margin-top: 0.2em;
+}
+
+/* ============================================================
+   PAGE BREAK UTILITIES
+   ============================================================ */
+
+.page-break {
+	page-break-after: always;
+}
+
+h1, h2 {
+	page-break-after: avoid;
+}
+
+tr, pre {
+	page-break-inside: avoid;
+}

--- a/src/__tests__/block-class-parser.test.ts
+++ b/src/__tests__/block-class-parser.test.ts
@@ -115,6 +115,56 @@ describe("parseBlockClasses", () => {
 	});
 });
 
+describe("parseBlockClasses — void elements (hr)", () => {
+	it("applies .page-break to an <hr> element", () => {
+		const input = `<hr>\n<p dir="auto">{.page-break}</p>`;
+		const output = parseBlockClasses(input);
+		expect(output).toContain('<hr class="page-break">');
+		expect(output).not.toContain("{.page-break}");
+	});
+
+	it("skips <hr> inside nested elements when tracking depth", () => {
+		const input = `<div><hr><p>text</p></div>\n<p dir="auto">{.wide}</p>`;
+		const output = parseBlockClasses(input);
+		expect(output).toContain('<div class="wide">');
+		expect(output).not.toContain("{.wide}");
+	});
+});
+
+describe("parseBlockClasses — callout + {.wide}", () => {
+	it("applies .wide to outer callout div (single-line callout)", () => {
+		// Obsidian renders callouts as nested divs. The entire callout opening
+		// is typically on one line, content on separate lines, closing on last line.
+		const input = [
+			'<div class="callout callout-stat-block" data-callout="stat-block"><div class="callout-title" dir="auto"><div class="callout-icon"><svg>x</svg></div><div class="callout-title-inner">stat-block</div></div><div class="callout-content">',
+			'<h2 data-heading="Goblin" dir="auto">Goblin</h2>',
+			'<p dir="auto"><em>Small humanoid</em></p>',
+			'<table>',
+			'<thead><tr><th>STR</th><th>DEX</th></tr></thead>',
+			'<tbody><tr><td>8</td><td>14</td></tr></tbody>',
+			'</table>',
+			'</div></div>',
+			'<p dir="auto">{.wide}</p>',
+		].join('\n');
+		const output = parseBlockClasses(input);
+		expect(output).toContain('callout-stat-block wide');
+		expect(output).not.toContain('{.wide}');
+	});
+
+	it("applies .wide to outer callout div (multi-line closing)", () => {
+		const input = [
+			'<div class="callout callout-stat-block" data-callout="stat-block"><div class="callout-title"><div class="callout-icon"></div><div class="callout-title-inner">stat-block</div></div><div class="callout-content">',
+			'<p>Content</p>',
+			'</div>',
+			'</div>',
+			'<p dir="auto">{.wide}</p>',
+		].join('\n');
+		const output = parseBlockClasses(input);
+		expect(output).toContain('callout-stat-block wide');
+		expect(output).not.toContain('{.wide}');
+	});
+});
+
 describe("applyCalloutClasses", () => {
 	// Custom callout type gets callout-<type> class
 	it("adds callout-stat-block class to a stat-block callout", () => {

--- a/src/block-class-parser.ts
+++ b/src/block-class-parser.ts
@@ -12,8 +12,11 @@ const ANNOTATION_REGEX = /^\{\s*(\.[a-zA-Z_][\w-]*(?:\s+\.[a-zA-Z_][\w-]*)*)\s*\
 const P_WRAPPED_ANNOTATION_RE = /^<p[^>]*>(\{[^<]+\})<\/p>$/;
 
 // Matches any block-level opening or closing tag
-const BLOCK_TAGS = "p|h[1-6]|ul|ol|li|blockquote|table|thead|tbody|tr|th|td|pre|div|figure|figcaption|section|article|aside|header|footer|main";
+const BLOCK_TAGS = "p|h[1-6]|ul|ol|li|blockquote|table|thead|tbody|tr|th|td|pre|div|figure|figcaption|section|article|aside|header|footer|main|hr";
 const TAG_RE = new RegExp(`<(/?)(?:${BLOCK_TAGS})(\\s[^>]*)?>`, "g");
+
+// Void (self-closing) elements — have no closing tag, so they don't affect depth
+const VOID_TAGS = new Set(["hr", "br", "img"]);
 
 /**
  * Parses {.classname} annotations in HTML and applies them as CSS classes
@@ -71,6 +74,19 @@ export function parseBlockClasses(html: string): string {
 			// Process tags right to left (we are walking the document backwards)
 			for (let k = tags.length - 1; k >= 0; k--) {
 				const tag = tags[k];
+
+				// Void elements (hr, br, img) have no closing tag — they don't
+				// affect nesting depth. If we encounter one at depth 0, it's a
+				// valid sibling target for the annotation.
+				if (VOID_TAGS.has(tag.tagName)) {
+					if (depth === 0) {
+						result[j] = injectClassAtPosition(resultLine, tag, classes);
+						applied = true;
+						break outer;
+					}
+					continue; // skip depth tracking
+				}
+
 				if (tag.isClose) {
 					depth++;
 				} else {

--- a/src/css-editor-view.ts
+++ b/src/css-editor-view.ts
@@ -159,7 +159,7 @@ export class CssEditorView extends ItemView {
 		// ── CM6 editor ──────────────────────────────────────────────────────
 		const editorEl = contentEl.createDiv({ cls: "typeset-css-editor-cm" });
 		editorEl.style.cssText = "flex:1;min-height:0;overflow:auto;";
-		const isBuiltIn = this.activeTheme?.isBuiltIn ?? false;
+		const isReadOnly = (this.activeTheme?.isBuiltIn && !this.plugin.settings.editBuiltInThemes) ?? false;
 
 		const state = EditorState.create({
 			doc: css,
@@ -170,10 +170,11 @@ export class CssEditorView extends ItemView {
 				syntaxHighlighting(defaultHighlightStyle),
 				// Search highlight decorations — reacts to setSearchQuery effects.
 				cssSearchField,
-				this.readOnlyCompartment.of(EditorState.readOnly.of(isBuiltIn)),
+				this.readOnlyCompartment.of(EditorState.readOnly.of(isReadOnly)),
 				EditorView.updateListener.of((update: ViewUpdate) => {
-					if (update.docChanged && !this.activeTheme?.isBuiltIn) {
-						this.scheduleSave();
+					if (update.docChanged) {
+						const locked = this.activeTheme?.isBuiltIn && !this.plugin.settings.editBuiltInThemes;
+						if (!locked) this.scheduleSave();
 					}
 				}),
 			],
@@ -181,7 +182,7 @@ export class CssEditorView extends ItemView {
 
 		this.cmView = new EditorView({ state, parent: editorEl });
 
-		if (isBuiltIn) this.setStatus("Read-only (built-in theme)");
+		if (isReadOnly) this.setStatus("Read-only (built-in theme)");
 
 		// getDisplayText() was called by Obsidian before onOpen() resolved
 		// the theme, so we force both the tab and the pane header to refresh.
@@ -234,17 +235,17 @@ export class CssEditorView extends ItemView {
 		if (this.dropdown) this.dropdown.value = theme.filename;
 
 		const css = await this.plugin.cssManager.loadThemeCss(theme);
-		const isBuiltIn = theme.isBuiltIn;
+		const isReadOnly = theme.isBuiltIn && !this.plugin.settings.editBuiltInThemes;
 
-		// Replace editor content and toggle read-only in one CM6 transaction.
+		// Replace editor content and toggle read-only based on theme + setting.
 		this.cmView.dispatch({
 			changes: { from: 0, to: this.cmView.state.doc.length, insert: css },
 			effects: this.readOnlyCompartment.reconfigure(
-				EditorState.readOnly.of(isBuiltIn),
+				EditorState.readOnly.of(isReadOnly),
 			),
 		});
 
-		this.setStatus(isBuiltIn ? "Read-only (built-in theme)" : "");
+		this.setStatus(isReadOnly ? "Read-only (built-in theme)" : "");
 		this.refreshPaneTitle();
 	}
 

--- a/src/css-manager.ts
+++ b/src/css-manager.ts
@@ -70,14 +70,12 @@ export class CssManager {
 	}
 
 	/**
-	 * Writes updated CSS content back to a user theme file on disk.
-	 * Built-in themes are read-only — calling this for one throws an Error.
+	 * Writes updated CSS content back to a theme file on disk.
+	 * Built-in themes save to built-in/; user themes save to themes/.
 	 */
 	async saveThemeCss(theme: ThemeInfo, css: string): Promise<void> {
-		if (theme.isBuiltIn) {
-			throw new Error(`[Typeset] Cannot overwrite built-in theme "${theme.filename}"`);
-		}
-		await this.app.vault.adapter.write(`${this.themesDir}/${theme.filename}`, css);
+		const dir = theme.isBuiltIn ? this.builtInDir : this.themesDir;
+		await this.app.vault.adapter.write(`${dir}/${theme.filename}`, css);
 	}
 
 	/**

--- a/src/document-builder.ts
+++ b/src/document-builder.ts
@@ -242,6 +242,8 @@ td { border-bottom: 1px solid var(--background-modifier-border, #ddd); }
 .callout, table, pre, blockquote { break-inside: avoid; }
 /* Keep headings attached to the content that follows them */
 h1, h2, h3, h4, h5, h6 { break-after: avoid; }
+/* Explicit page break via {.page-break} annotation */
+.page-break { break-after: page; }
 
 .copy-code-button { display: none; }
 }

--- a/src/preview-view.ts
+++ b/src/preview-view.ts
@@ -284,135 +284,199 @@ export class TypesetPreviewView extends ItemView {
 			const scrollEl     = doc.getElementById("typeset-scroll");
 			if (!measure || !pagesContainer || !scrollEl) return;
 
-			const totalHeight = measure.scrollHeight;
-			const contentHtml = measure.innerHTML;
-			const measureTop  = measure.getBoundingClientRect().top;
+			// ── Detect theme columns ─────────────────────────────────────────
+			const colCountMatch = themeCss.match(/column-count\s*:\s*(\d+)/);
+			const colGapMatch   = themeCss.match(/column-gap\s*:\s*([\d.]+\w+)/);
+			const themeColCount = colCountMatch ? parseInt(colCountMatch[1], 10) : 1;
+			const themeColGap   = colGapMatch   ? colGapMatch[1] : "20pt";
+			const isColumned    = themeColCount >= 2;
 
-			// ── Block element map ─────────────────────────────────────────────
-			// Collect all significant block elements with their measured positions.
-			// We check each element for two CSS hints:
-			//   avoidBreakInside — .callout, table, pre: never split mid-element
-			//   avoidBreakAfter  — h1–h6: keep heading glued to the content below it
-			type Block = { top: number; bottom: number; avoidBreakInside: boolean; avoidBreakAfter: boolean };
-			const blocks: Block[] = Array.from(
-				measure.querySelectorAll("p, h1, h2, h3, h4, h5, h6, ul, ol, blockquote, pre, table, .callout, hr, img"),
-			).map(el => {
-				const r = el.getBoundingClientRect();
-				const isHeading  = /^H[1-6]$/.test(el.tagName);
-				const isAvoidInside = el.classList.contains("callout")
-					|| el.tagName === "TABLE"
-					|| el.tagName === "PRE"
-					|| el.tagName === "BLOCKQUOTE";
-				return {
-					top:              r.top    - measureTop,
-					bottom:           r.bottom - measureTop,
-					avoidBreakInside: isAvoidInside,
-					avoidBreakAfter:  isHeading,
+			if (isColumned) {
+				// ── Columned pagination: overflow detection ───────────────────
+				// The browser's native column engine handles column layout.
+				// We create an off-screen measurement container matching one
+				// page's content area (with balanced columns, no height
+				// constraint) and append elements one by one.  When the
+				// balanced column height exceeds the page's content area,
+				// we know the page is full and start a new one.
+				const elements = Array.from(measure.children) as HTMLElement[];
+				const pages: HTMLElement[][] = [];
+				let currentPage: HTMLElement[] = [];
+
+				const createMC = (): HTMLDivElement => {
+					const mc = doc.createElement("div");
+					mc.className = "markdown-rendered";
+					mc.style.cssText =
+						`position:absolute;left:-9999px;visibility:hidden;` +
+						`width:${contentAreaWidthPx}px;` +
+						`column-count:${themeColCount};column-gap:${themeColGap};` +
+						`column-fill:balance;`;
+					scrollEl.appendChild(mc);
+					return mc;
 				};
-			}).sort((a, b) => a.top - b.top);
 
-			// ── Smart break finder ────────────────────────────────────────────
-			// Given the previous page's break position and the raw target
-			// (prevBreak + pageHeightPx), return a clean break position that:
-			//   • doesn't split any avoidBreakInside element (callout, table, pre)
-			//   • doesn't break immediately after a heading — keeps heading + first
-			//     content together (avoidBreakAfter)
-			//
-			// Key invariant: the "revert to before-heading" logic fires ONLY when
-			// the block that follows the heading STRADDLES the boundary.  When the
-			// heading and the block both fit, bestBreak advances normally.
-			function smartBreak(prevBreak: number, target: number): number {
-				let bestBreak        = prevBreak; // best clean break found so far
-				let beforeHeadingPos = prevBreak; // bestBreak value just before a heading
-				let pendingHeading   = false;     // true while last seen block was a heading
+				let mc = createMC();
 
-				for (const b of blocks) {
-					if (b.top <= prevBreak) continue; // before our window
-					if (b.top >= target)   break;      // past the boundary
+				for (let idx = 0; idx < elements.length; idx++) {
+					const el = elements[idx];
+					const clone = el.cloneNode(true) as HTMLElement;
+					mc.appendChild(clone);
 
-					if (b.bottom <= target) {
-						// ── Block fits entirely on this page ─────────────────────
-						if (b.avoidBreakAfter) {
-							// Heading fits — remember the break point just before it so
-							// we can retreat here if the *next* block doesn't fit.
-							if (!pendingHeading) beforeHeadingPos = bestBreak;
-							pendingHeading = true;
-							// Don't advance bestBreak yet; wait to see if next content fits.
+					if (mc.scrollHeight > contentAreaHeightPx) {
+						// This element pushed us past the page boundary.
+						mc.removeChild(clone);
+
+						// Heading sticking: if the last element on the current
+						// page is a heading, pull it to the next page so it
+						// stays with the content that follows it.
+						if (
+							currentPage.length > 0 &&
+							/^H[1-6]$/.test(currentPage[currentPage.length - 1].tagName)
+						) {
+							const heading = currentPage.pop()!;
+							if (mc.lastChild) mc.removeChild(mc.lastChild);
+							pages.push([...currentPage]);
+							mc.remove();
+							mc = createMC();
+							currentPage = [heading, el];
+							mc.appendChild(heading.cloneNode(true));
+							mc.appendChild(el.cloneNode(true));
 						} else {
-							// Non-heading block fits.  Always advance bestBreak.
-							// (If a heading preceded it and BOTH fit, heading stays on this
-							// page with its content — no revert needed.)
-							bestBreak     = b.bottom;
-							pendingHeading = false;
+							pages.push([...currentPage]);
+							mc.remove();
+							mc = createMC();
+							currentPage = [el];
+							mc.appendChild(el.cloneNode(true));
 						}
 					} else {
-						// ── Block straddles the boundary ─────────────────────────
-						if (pendingHeading) {
-							// Content after the heading doesn't fit — retreat to just
-							// before the heading so it travels with its content to p.N+1.
-							bestBreak = beforeHeadingPos;
-						} else {
-							// No pending heading — break just before this block.
-							bestBreak = b.top > prevBreak ? b.top : prevBreak;
-						}
-						break;
+						currentPage.push(el);
 					}
 				}
 
-				// Fall back to the raw boundary if no clean break was found.
-				return bestBreak > prevBreak ? bestBreak : target;
-			}
+				// Last page
+				if (currentPage.length > 0) pages.push(currentPage);
+				mc.remove();
 
-			// ── Calculate page start offsets ──────────────────────────────────
-			const pageStarts: number[] = [0];
-			let prev = 0;
-			while (prev < totalHeight) {
-				const target = prev + contentAreaHeightPx;
-				if (target >= totalHeight) break;
-				const next = smartBreak(prev, target);
-				pageStarts.push(next);
-				prev = next;
-			}
+				// ── Build columned page boxes ────────────────────────────────
+				for (let i = 0; i < pages.length; i++) {
+					const pageBox = doc.createElement("div");
+					pageBox.className = "typeset-page-box";
 
-			// ── Build page boxes ──────────────────────────────────────────────
-			for (let i = 0; i < pageStarts.length; i++) {
-				const pageBox = doc.createElement("div");
-				pageBox.className = "typeset-page-box";
+					const label = doc.createElement("div");
+					label.className = "typeset-page-label";
+					label.textContent = `${i + 1}`;
+					pageBox.appendChild(label);
 
-				const label = doc.createElement("div");
-				label.className = "typeset-page-label";
-				label.textContent = `${i + 1}`;
-				pageBox.appendChild(label);
+					const content = doc.createElement("div");
+					content.className = "typeset-page-content markdown-rendered";
+					content.style.cssText =
+						`position:static;` +
+						`column-count:${themeColCount};column-gap:${themeColGap};column-fill:auto;` +
+						`padding:${marginCss};box-sizing:border-box;` +
+						`width:${pageWidthPx}px;height:${pageHeightPx}px;overflow:hidden;`;
 
-				// Calculate the exact height of this page's content slice.
-				// Without this clip, smart breaks cause content to repeat:
-				// page N still shows up to pageHeightPx even if pageStarts[N+1]
-				// was moved back, so the overlapping region shows on both pages.
-				const nextStart      = i + 1 < pageStarts.length ? pageStarts[i + 1] : totalHeight;
-				const contentHeight  = nextStart - pageStarts[i];
+					for (const el of pages[i]) {
+						content.appendChild(el.cloneNode(true));
+					}
 
-				const clip = doc.createElement("div");
-				// Pages 2+ need margin-top to recreate the top margin space
-				// (page 1 gets it from the content div's CSS padding-top).
-				const clipMargin = i === 0 ? 0 : topMarginPx;
-				clip.style.cssText = `height:${contentHeight}px;overflow:hidden;position:relative;margin-top:${clipMargin}px;`;
-
-				const content = doc.createElement("div");
-				content.className = "typeset-page-content markdown-rendered";
-				if (i > 0) {
-					// Remove top padding — the clip's margin-top provides the space.
-					// Compensate the top offset: without padding, content shifts up
-					// by topMarginPx, so add it back to keep alignment correct.
-					content.style.top = `${-pageStarts[i] + topMarginPx}px`;
-					content.style.setProperty("padding-top", "0px", "important");
-				} else {
-					content.style.top = `${-pageStarts[i]}px`;
+					pageBox.appendChild(content);
+					pagesContainer.appendChild(pageBox);
 				}
-				content.innerHTML = contentHtml;
+			} else {
+				// ── Non-columned pagination: clip-based approach ──────────────
+				const totalHeight = measure.scrollHeight;
+				const measureTop  = measure.getBoundingClientRect().top;
 
-				clip.appendChild(content);
-				pageBox.appendChild(clip);
-				pagesContainer.appendChild(pageBox);
+				type Block = { top: number; bottom: number; avoidBreakInside: boolean; avoidBreakAfter: boolean };
+				const blocks: Block[] = Array.from(
+					measure.querySelectorAll("p, h1, h2, h3, h4, h5, h6, ul, ol, blockquote, pre, table, .callout, hr, img"),
+				).map(el => {
+					const r = el.getBoundingClientRect();
+					const isHeading  = /^H[1-6]$/.test(el.tagName);
+					const isAvoidInside = el.classList.contains("callout")
+						|| el.tagName === "TABLE"
+						|| el.tagName === "PRE"
+						|| el.tagName === "BLOCKQUOTE";
+					return {
+						top:              r.top    - measureTop,
+						bottom:           r.bottom - measureTop,
+						avoidBreakInside: isAvoidInside,
+						avoidBreakAfter:  isHeading,
+					};
+				}).sort((a, b) => a.top - b.top);
+
+				function smartBreak(prevBreak: number, target: number): number {
+					let bestBreak        = prevBreak;
+					let beforeHeadingPos = prevBreak;
+					let pendingHeading   = false;
+
+					for (const b of blocks) {
+						if (b.top <= prevBreak) continue;
+						if (b.top >= target)   break;
+
+						if (b.bottom <= target) {
+							if (b.avoidBreakAfter) {
+								if (!pendingHeading) beforeHeadingPos = bestBreak;
+								pendingHeading = true;
+							} else {
+								bestBreak     = b.bottom;
+								pendingHeading = false;
+							}
+						} else {
+							if (pendingHeading) {
+								bestBreak = beforeHeadingPos;
+							} else {
+								bestBreak = b.top > prevBreak ? b.top : prevBreak;
+							}
+							break;
+						}
+					}
+
+					return bestBreak > prevBreak ? bestBreak : target;
+				}
+
+				const pageStarts: number[] = [0];
+				let prev = 0;
+				while (prev < totalHeight) {
+					const target = prev + contentAreaHeightPx;
+					if (target >= totalHeight) break;
+					const next = smartBreak(prev, target);
+					pageStarts.push(next);
+					prev = next;
+				}
+
+				const contentHtml = measure.innerHTML;
+
+				for (let i = 0; i < pageStarts.length; i++) {
+					const pageBox = doc.createElement("div");
+					pageBox.className = "typeset-page-box";
+
+					const label = doc.createElement("div");
+					label.className = "typeset-page-label";
+					label.textContent = `${i + 1}`;
+					pageBox.appendChild(label);
+
+					const nextStart      = i + 1 < pageStarts.length ? pageStarts[i + 1] : totalHeight;
+					const contentHeight  = nextStart - pageStarts[i];
+
+					const clip = doc.createElement("div");
+					const clipMargin = i === 0 ? 0 : topMarginPx;
+					clip.style.cssText = `height:${contentHeight}px;overflow:hidden;position:relative;margin-top:${clipMargin}px;`;
+
+					const content = doc.createElement("div");
+					content.className = "typeset-page-content markdown-rendered";
+					if (i > 0) {
+						content.style.top = `${-pageStarts[i] + topMarginPx}px`;
+						content.style.setProperty("padding-top", "0px", "important");
+					} else {
+						content.style.top = `${-pageStarts[i]}px`;
+					}
+					content.innerHTML = contentHtml;
+
+					clip.appendChild(content);
+					pageBox.appendChild(clip);
+					pagesContainer.appendChild(pageBox);
+				}
 			}
 
 			measure.remove();
@@ -650,6 +714,9 @@ html, body {
 	height:   auto;
 	overflow: auto;
 	background: #d0d0d0;
+	/* Reset theme columns — preview uses clip-based pagination which is
+	   incompatible with CSS column-count.  Columns work in PDF natively. */
+	column-count: auto;
 }
 
 /* ── Grey surround ──────────────────────────────────────────────────────── */

--- a/src/preview-view.ts
+++ b/src/preview-view.ts
@@ -38,6 +38,10 @@ export class TypesetPreviewView extends ItemView {
 	private currentThemeName = "";
 	private iframeEl: HTMLIFrameElement | null = null;
 	private debounceTimer: number | null = null;
+	private zoomMode: "fit-width" | "fit-page" | "manual" = "fit-width";
+	private manualZoom = 1; // 0.25–2.0
+	private lastPageWidthPx = 0;
+	private lastPageHeightPx = 0;
 
 	// ── Render cache ──────────────────────────────────────────────────────────
 	// Themes and CSS are re-loaded from disk only when the active theme changes,
@@ -303,6 +307,33 @@ export class TypesetPreviewView extends ItemView {
 				const pages: HTMLElement[][] = [];
 				let currentPage: HTMLElement[] = [];
 
+				// ── Normalization pre-pass ────────────────────────────
+				// Convert ALL break directives into a single breakBefore
+				// flag per element. This means:
+				//   1. Elements with CSS break-before (e.g. stat-block-wide)
+				//      or .break-before class → breakBefore = true
+				//   2. Elements with .page-break (break-after) → the NEXT
+				//      element gets breakBefore = true
+				// After this, the main loop only ever checks breakBefore.
+				const breakBefore = new Set<number>();
+
+				for (let idx = 0; idx < elements.length; idx++) {
+					const el = elements[idx];
+					if (!el.classList) continue;
+
+					// Direct break-before: element wants a new page before it
+					if (el.classList.contains("break-before") ||
+						el.classList.contains("callout-stat-block-wide")) {
+						breakBefore.add(idx);
+					}
+
+					// Break-after (.page-break): normalize to break-before
+					// on the NEXT element
+					if (el.classList.contains("page-break") && idx + 1 < elements.length) {
+						breakBefore.add(idx + 1);
+					}
+				}
+
 				const createMC = (): HTMLDivElement => {
 					const mc = doc.createElement("div");
 					mc.className = "markdown-rendered";
@@ -319,6 +350,17 @@ export class TypesetPreviewView extends ItemView {
 
 				for (let idx = 0; idx < elements.length; idx++) {
 					const el = elements[idx];
+
+					// ── Forced page break ────────────────────────────
+					// If this element has breakBefore and the current page
+					// isn't empty, finalize the current page first.
+					if (breakBefore.has(idx) && currentPage.length > 0) {
+						pages.push([...currentPage]);
+						mc.remove();
+						mc = createMC();
+						currentPage = [];
+					}
+
 					const clone = el.cloneNode(true) as HTMLElement;
 					mc.appendChild(clone);
 
@@ -387,6 +429,11 @@ export class TypesetPreviewView extends ItemView {
 				const totalHeight = measure.scrollHeight;
 				const measureTop  = measure.getBoundingClientRect().top;
 
+				// Collect forced page-break positions from .page-break elements
+				const forceBreaks: number[] = Array.from(
+					measure.querySelectorAll(".page-break"),
+				).map(el => el.getBoundingClientRect().bottom - measureTop);
+
 				type Block = { top: number; bottom: number; avoidBreakInside: boolean; avoidBreakAfter: boolean };
 				const blocks: Block[] = Array.from(
 					measure.querySelectorAll("p, h1, h2, h3, h4, h5, h6, ul, ol, blockquote, pre, table, .callout, hr, img"),
@@ -438,7 +485,14 @@ export class TypesetPreviewView extends ItemView {
 				const pageStarts: number[] = [0];
 				let prev = 0;
 				while (prev < totalHeight) {
+					// Check for forced page breaks before the natural target
 					const target = prev + contentAreaHeightPx;
+					const forcedBreak = forceBreaks.find(fb => fb > prev && fb <= target);
+					if (forcedBreak !== undefined) {
+						pageStarts.push(forcedBreak);
+						prev = forcedBreak;
+						continue;
+					}
 					if (target >= totalHeight) break;
 					const next = smartBreak(prev, target);
 					pageStarts.push(next);
@@ -481,10 +535,10 @@ export class TypesetPreviewView extends ItemView {
 
 			measure.remove();
 
-			// ── Fit to width ──────────────────────────────────────────────────
-			const available = scrollEl.clientWidth - 64; // 32px padding each side
-			const scale     = Math.min(1, available / pageWidthPx);
-			pagesContainer.style.zoom = String(scale);
+			// ── Apply zoom ────────────────────────────────────────────────────
+			this.lastPageWidthPx = pageWidthPx;
+			this.lastPageHeightPx = pageHeightPx;
+			this.applyZoom();
 
 			// Restore scroll position after re-render.
 			if (prevScroll > 0) scrollEl.scrollTop = prevScroll;
@@ -494,6 +548,45 @@ export class TypesetPreviewView extends ItemView {
 	}
 
 	// ── Private helpers ───────────────────────────────────────────────────────
+
+	private applyZoom(): void {
+		const doc = this.iframeEl?.contentDocument;
+		if (!doc) return;
+		const scrollEl = doc.getElementById("typeset-scroll");
+		const pagesContainer = doc.getElementById("typeset-pages");
+		if (!scrollEl || !pagesContainer) return;
+
+		let scale: number;
+		if (this.zoomMode === "fit-width") {
+			const available = scrollEl.clientWidth - 16; // 8px padding each side
+			scale = Math.min(1, available / this.lastPageWidthPx);
+		} else if (this.zoomMode === "fit-page") {
+			const availW = scrollEl.clientWidth - 16;
+			const availH = scrollEl.clientHeight - 16;
+			const scaleW = availW / this.lastPageWidthPx;
+			const scaleH = availH / this.lastPageHeightPx;
+			scale = Math.min(1, scaleW, scaleH);
+		} else {
+			scale = this.manualZoom;
+		}
+
+		pagesContainer.style.zoom = String(scale);
+	}
+
+	private setZoomMode(mode: "fit-width" | "fit-page" | "manual", manualValue?: number): void {
+		this.zoomMode = mode;
+		if (manualValue !== undefined) this.manualZoom = manualValue;
+		this.applyZoom();
+		// Update the zoom label in the info bar
+		const label = this.infoBarEl?.querySelector(".typeset-zoom-label");
+		if (label) label.textContent = this.getZoomLabel();
+	}
+
+	private getZoomLabel(): string {
+		if (this.zoomMode === "fit-width") return "Fit Width";
+		if (this.zoomMode === "fit-page") return "Fit Page";
+		return `${Math.round(this.manualZoom * 100)}%`;
+	}
 
 	private updateInfoBar(file: TFile, themeName: string): void {
 		if (!this.infoBarEl) return;
@@ -530,6 +623,55 @@ export class TypesetPreviewView extends ItemView {
 		themeChip.addEventListener("mouseenter", () => themeChip.style.background = "var(--background-modifier-hover)");
 		themeChip.addEventListener("mouseleave", () => themeChip.style.background = "");
 		themeChip.addEventListener("click", () => this.openThemePicker());
+
+		// Spacer pushes zoom controls to the right
+		const spacer = this.infoBarEl.createSpan();
+		spacer.style.cssText = "flex:1;";
+
+		// Zoom out button
+		const zoomOutBtn = this.infoBarEl.createSpan();
+		zoomOutBtn.style.cssText = chipCss;
+		zoomOutBtn.setAttribute("aria-label", "Zoom out");
+		const zoomOutIcon = zoomOutBtn.createSpan();
+		setIcon(zoomOutIcon, "lucide-minus");
+		zoomOutIcon.style.cssText = "display:flex;align-items:center;width:12px;height:12px;";
+		zoomOutBtn.addEventListener("mouseenter", () => zoomOutBtn.style.background = "var(--background-modifier-hover)");
+		zoomOutBtn.addEventListener("mouseleave", () => zoomOutBtn.style.background = "");
+		zoomOutBtn.addEventListener("click", () => {
+			const newZoom = Math.max(0.25, (this.zoomMode === "manual" ? this.manualZoom : 1) - 0.1);
+			this.setZoomMode("manual", Math.round(newZoom * 100) / 100);
+		});
+
+		// Zoom label — click cycles through modes
+		const zoomLabel = this.infoBarEl.createSpan({ cls: "typeset-zoom-label" });
+		zoomLabel.style.cssText = chipCss + "min-width:60px;justify-content:center;user-select:none;";
+		zoomLabel.textContent = this.getZoomLabel();
+		zoomLabel.setAttribute("aria-label", "Click to cycle: Fit Width → Fit Page → manual");
+		zoomLabel.addEventListener("mouseenter", () => zoomLabel.style.background = "var(--background-modifier-hover)");
+		zoomLabel.addEventListener("mouseleave", () => zoomLabel.style.background = "");
+		zoomLabel.addEventListener("click", () => {
+			if (this.zoomMode === "fit-width") {
+				this.setZoomMode("fit-page");
+			} else if (this.zoomMode === "fit-page") {
+				this.setZoomMode("manual", 1);
+			} else {
+				this.setZoomMode("fit-width");
+			}
+		});
+
+		// Zoom in button
+		const zoomInBtn = this.infoBarEl.createSpan();
+		zoomInBtn.style.cssText = chipCss;
+		zoomInBtn.setAttribute("aria-label", "Zoom in");
+		const zoomInIcon = zoomInBtn.createSpan();
+		setIcon(zoomInIcon, "lucide-plus");
+		zoomInIcon.style.cssText = "display:flex;align-items:center;width:12px;height:12px;";
+		zoomInBtn.addEventListener("mouseenter", () => zoomInBtn.style.background = "var(--background-modifier-hover)");
+		zoomInBtn.addEventListener("mouseleave", () => zoomInBtn.style.background = "");
+		zoomInBtn.addEventListener("click", () => {
+			const newZoom = Math.min(2, (this.zoomMode === "manual" ? this.manualZoom : 1) + 0.1);
+			this.setZoomMode("manual", Math.round(newZoom * 100) / 100);
+		});
 	}
 
 	private async exportPdf(): Promise<void> {
@@ -722,7 +864,7 @@ html, body {
 /* ── Grey surround ──────────────────────────────────────────────────────── */
 #typeset-scroll {
 	background: #d0d0d0;
-	padding: 32px;
+	padding: 8px;
 	box-sizing: border-box;
 	overflow-x: auto;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -46,6 +46,7 @@ export const DEFAULT_SETTINGS: TypesetSettings = {
 	},
 	activeTheme: "default.css",
 	outputFolder: "",
+	editBuiltInThemes: false,
 };
 
 // Page dimensions in mm — used to warn when margins exceed the page size.
@@ -391,6 +392,23 @@ export class TypesetSettingTab extends PluginSettingTab {
 		makeField("right", updateLR);
 		lrWarning = containerEl.createDiv({ cls: "typeset-margin-pair-warning" });
 		updateLR();
+
+		// --- Advanced ---
+		containerEl.createEl("h3", { text: "Advanced" });
+
+		new Setting(containerEl)
+			.setName("Edit built-in themes")
+			.setDesc(
+				"Allow editing built-in themes directly in the CSS editor. Changes are saved back to the plugin's built-in folder.",
+			)
+			.addToggle(toggle =>
+				toggle
+					.setValue(this.settings.editBuiltInThemes)
+					.onChange(async value => {
+						this.settings.editBuiltInThemes = value;
+						await this.save(this.settings);
+					}),
+			);
 
 		// --- Export ---
 		containerEl.createEl("h3", { text: "Export" });

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface TypesetSettings {
 	defaultLayout: PageLayout;
 	activeTheme: string; // filename of the active CSS theme
 	outputFolder: string; // where to save exported PDFs
+	editBuiltInThemes: boolean; // allow editing built-in themes in the CSS editor
 }
 
 export interface ThemeInfo {


### PR DESCRIPTION
## Features

### Preview Improvements
- **Stat blocks & columned layout**: Implement native CSS column pagination for two-column themes (e.g., D&D Homebrew)
- **Zoom controls**: Add fit-width, fit-page, and manual zoom modes with +/− buttons in the preview toolbar
- **Page breaks**: Support explicit `{.page-break}` annotations and heading-sticking logic

### D&D Homebrew Theme
- Complete style system with two-column layout, stat block formatting, callouts (read-aloud, magic items, warnings)
- Print-ready typography, colors, and spacing for D&D 5e documents
- Support for stat-block-wide variant that spans full page width

### CSS Editor
- **Edit built-in themes**: New "Edit built-in themes" setting allows users to modify built-in CSS files directly
- Read-only toggle removed for built-in themes when setting is enabled
- Built-in theme changes persist in the plugin's built-in folder

### Parser Enhancements
- Handle void elements (hr, br, img) in block class parser
- Properly apply class annotations to hr elements and callouts with page-break directives

## Technical Changes
- Columned pagination uses element cloning + balanced columns for accurate page splits
- Non-columned pagination improved with forced break detection and heading-content grouping
- Zoom state management with manual/auto modes and viewport resizing
- Settings tab extended with Advanced section for theme editing control